### PR TITLE
refactor: rename ui_control_module -> coordinator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__*
 */.DS_Store
 .DS_Store
 tmp
+*.egg-info

--- a/tests/test_ui_control_module.py
+++ b/tests/test_ui_control_module.py
@@ -1,6 +1,6 @@
 import time
 from vent.common.message import ControlSettings, ControlSettingName
-from vent.coordinator.ui_control_module import get_ui_control_module
+from vent.coordinator.coordinator import get_coordinator
 import pytest
 import random
 
@@ -11,19 +11,19 @@ import random
                                                   ControlSettingName.BREATHS_PER_MINUTE,
                                                   ControlSettingName.INSPIRATION_TIME_SEC])
 def test_control_single_process_simulation(control_setting_name):
-    ui_control_module = get_ui_control_module(single_process=True, sim_mode=True)
+    coordinator = get_coordinator(single_process=True, sim_mode=True)
     t = time.time()
     v = random.randint(10, 100)
     v_min = v - 5
     v_max = v + 5
     c = ControlSettings(name=control_setting_name, value=v, min_value=v_min, max_value=v_max, timestamp=t)
-    ui_control_module.set_controls(c)
-    c_read = ui_control_module.get_controls(control_setting_name)
+    coordinator.set_controls(c)
+    c_read = coordinator.get_controls(control_setting_name)
 
     assert c_read.name == c.name
     assert c_read.value == c.value
     assert c_read.min_value == c.min_value
     assert c_read.max_value == c.max_value
     assert c_read.timestamp == c.timestamp
-    assert ui_control_module.get_msg_timestamp() == t
+    assert coordinator.get_msg_timestamp() == t
 

--- a/vent/coordinator/coordinator.py
+++ b/vent/coordinator/coordinator.py
@@ -6,7 +6,7 @@ from vent.common.message import SensorValues, ControlSettings, Alarm, ControlSet
 from vent.coordinator.process_manager import ProcessManager
 
 
-class UIControlModuleBase:
+class CoordinatorBase:
     def __init__(self, sim_mode=False):
         # get_ui_control_module handles single_process flag
         self.control_module = get_control_module(sim_mode)
@@ -54,7 +54,7 @@ class UIControlModuleBase:
             raise KeyError("Error: undefined action" + str(command))
 
 
-class UIControlModuleLocal(UIControlModuleBase):
+class CoordinatorLocal(CoordinatorBase):
     def __init__(self, sim_mode=False):
         super().__init__(sim_mode=sim_mode)
         self.thread_id = None  # TODO: do I need a thread
@@ -84,11 +84,10 @@ class UIControlModuleLocal(UIControlModuleBase):
         return self.last_message_timestamp
 
     def do_process(self, command):
-
         super().do_process(command)
 
 
-class UIControlModuleRemote(UIControlModuleBase):
+class CoordinatorRemote(CoordinatorBase):
     def __init__(self, sim_mode=False):
         super().__init__(sim_mode=sim_mode)
         # TODO: pass max_heartbeat_interval
@@ -97,8 +96,8 @@ class UIControlModuleRemote(UIControlModuleBase):
         raise NotImplementedError
 
 
-def get_ui_control_module(single_process=False, sim_mode=False):
+def get_coordinator(single_process=False, sim_mode=False):
     if single_process == True:
-        return UIControlModuleLocal(sim_mode)
+        return CoordinatorLocal(sim_mode)
     else:
-        return UIControlModuleRemote(sim_mode)
+        return CoordinatorRemote(sim_mode)

--- a/vent/main.py
+++ b/vent/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import argparse
-from vent.coordinator.ui_control_module import get_ui_control_module
+from vent.coordinator.coordinator import get_coordinator
 
 
 def parse_cmd_args():
@@ -14,7 +14,7 @@ def parse_cmd_args():
 
 def main():
     args = parse_cmd_args()
-    ui_control_module = get_ui_control_module(single_process=args.single_process, sim_mode=args.simulation)
+    coordinator = get_coordinator(single_process=args.single_process, sim_mode=args.simulation)
     # TODO: gui.main(ui_control_module)
 
 


### PR DESCRIPTION
Globally rename ui_control_module to coordinator to prevent confusion with controller

Also change the naming in Software Architecture (https://docs.google.com/document/d/13eqc3OJCYJAI3sxCdSosR6H6VLpEPJxDEBhGktyFTHg/edit#)