### PR TITLE
refactor: define ValueName for all variable namesa in message

### DIFF
--- a/sandbox/testPIDControllerClass.ipynb
+++ b/sandbox/testPIDControllerClass.ipynb
@@ -14,7 +14,7 @@
     "sys.path.append('../') # get out of the sandbox\n",
     "\n",
     "from vent.controller.control_module import get_control_module\n",
-    "from vent.common.message import SensorValues, ControlSetting, Alarm, AlarmSeverity, ControlSettingName"
+    "from vent.common.message import SensorValues, ControlSetting, Alarm, AlarmSeverity, ValueName"
    ]
   },
   {
@@ -109,10 +109,10 @@
    "source": [
     "pl.rcParams['figure.figsize'] = [15, 4]\n",
     "\n",
-    "cc = Controller.get_control(control_setting_name = ControlSettingName.PEEP)\n",
+    "cc = Controller.get_control(control_setting_name = ValueName.PEEP)\n",
     "peep = cc.value\n",
     "\n",
-    "cc = Controller.get_control(control_setting_name = ControlSettingName.PEEP)\n",
+    "cc = Controller.get_control(control_setting_name = ValueName.PEEP)\n",
     "pip = cc.value\n",
     "\n",
     "pl.plot(tt, [s.pressure for s in ls], label = 'pressure')\n",

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -3,16 +3,16 @@ import numpy as np
 import pytest
 import random
 
-from vent.common.message import SensorValues, ControlSetting, Alarm, AlarmSeverity, ControlSettingName
+from vent.common.message import SensorValues, ControlSetting, Alarm, AlarmSeverity, ValueName
 from vent.coordinator.coordinator import get_coordinator
 from vent.controller.control_module import get_control_module
 
 
-@pytest.mark.parametrize("control_setting_name", [ControlSettingName.PIP,
-                                                  ControlSettingName.PIP_TIME,
-                                                  ControlSettingName.PEEP,
-                                                  ControlSettingName.BREATHS_PER_MINUTE,
-                                                  ControlSettingName.INSPIRATION_TIME_SEC])
+@pytest.mark.parametrize("control_setting_name", [ValueName.PIP,
+                                                  ValueName.PIP_TIME,
+                                                  ValueName.PEEP,
+                                                  ValueName.BREATHS_PER_MINUTE,
+                                                  ValueName.INSPIRATION_TIME_SEC])
 
 def test_control_settingss(control_setting_name):
     '''
@@ -51,19 +51,19 @@ def test_control_dynamical():
     vals_start = Controller.get_sensors()
 
     v_peep = random.randint(5, 15)
-    command = ControlSetting(name=ControlSettingName.PEEP, value=v_peep, min_value=v_peep-1, max_value=v_peep+1, timestamp=time.time())
+    command = ControlSetting(name=ValueName.PEEP, value=v_peep, min_value=v_peep - 1, max_value=v_peep + 1, timestamp=time.time())
     Controller.set_control(command)
 
     v_pip = random.randint(15, 25)
-    command = ControlSetting(name=ControlSettingName.PIP, value=v_pip, min_value=v_pip-1, max_value=v_pip+1, timestamp=time.time())
+    command = ControlSetting(name=ValueName.PIP, value=v_pip, min_value=v_pip - 1, max_value=v_pip + 1, timestamp=time.time())
     Controller.set_control(command)
 
     v_bpm = random.randint(6, 25)
-    command = ControlSetting(name=ControlSettingName.BREATHS_PER_MINUTE, value=v_bpm, min_value=v_bpm-1, max_value=v_bpm+1, timestamp=time.time()) 
+    command = ControlSetting(name=ValueName.BREATHS_PER_MINUTE, value=v_bpm, min_value=v_bpm - 1, max_value=v_bpm + 1, timestamp=time.time())
     Controller.set_control(command)
 
     v_iphase = (0.3 + np.random.random()*0.5) * 60/v_bpm
-    command = ControlSetting(name=ControlSettingName.INSPIRATION_TIME_SEC, value=v_iphase, min_value=v_iphase-1, max_value=v_iphase+1, timestamp=time.time()) 
+    command = ControlSetting(name=ValueName.INSPIRATION_TIME_SEC, value=v_iphase, min_value=v_iphase - 1, max_value=v_iphase + 1, timestamp=time.time())
     Controller.set_control(command)
 
     Controller.start()
@@ -143,24 +143,24 @@ def test_alarm():
 
         ### Make a cascade of changes that will not trigger alarms
         if t == 0:
-            command = ControlSetting(name=ControlSettingName.BREATHS_PER_MINUTE, value=17, min_value=0, max_value=30, timestamp=time.time())
+            command = ControlSetting(name=ValueName.BREATHS_PER_MINUTE, value=17, min_value=0, max_value=30, timestamp=time.time())
             Controller.set_control(command)
         if t == 3:
-            command = ControlSetting(name=ControlSettingName.PIP, value=25, min_value=0, max_value=30, timestamp=time.time())
+            command = ControlSetting(name=ValueName.PIP, value=25, min_value=0, max_value=30, timestamp=time.time())
             Controller.set_control(command)
         if t == 7:
-            command = ControlSetting(name=ControlSettingName.INSPIRATION_TIME_SEC, value=1.5, min_value=0, max_value=2, timestamp=time.time())
+            command = ControlSetting(name=ValueName.INSPIRATION_TIME_SEC, value=1.5, min_value=0, max_value=2, timestamp=time.time())
             Controller.set_control(command)
         if t == 10:
-            command = ControlSetting(name=ControlSettingName.PEEP, value=10, min_value=0, max_value=20, timestamp=time.time())
+            command = ControlSetting(name=ValueName.PEEP, value=10, min_value=0, max_value=20, timestamp=time.time())
             Controller.set_control(command)
 
         ### Make a cascade of changes to trigger four alarms
         if t == 8:    # trigger a PIP alarm
-            command = ControlSetting(name=ControlSettingName.PIP, value=25, min_value=0, max_value=5, timestamp=time.time())
+            command = ControlSetting(name=ValueName.PIP, value=25, min_value=0, max_value=5, timestamp=time.time())
             Controller.set_control(command)
         if t == 23:    #resolve the PIP alarm
-            command = ControlSetting(name=ControlSettingName.PIP, value=25, min_value=0, max_value=30, timestamp=time.time())
+            command = ControlSetting(name=ValueName.PIP, value=25, min_value=0, max_value=30, timestamp=time.time())
             Controller.set_control(command)
         if (t > 8+(60/17)) and (t<23):  #T est whether it is active
             activealarms = Controller.get_active_alarms()
@@ -168,10 +168,10 @@ def test_alarm():
             assert 'PIP' in activealarms.keys()
 
         if t == 12:    # trigger a PEEP alarm
-            command = ControlSetting(name=ControlSettingName.PEEP, value=10, min_value=0, max_value=5, timestamp=time.time())
+            command = ControlSetting(name=ValueName.PEEP, value=10, min_value=0, max_value=5, timestamp=time.time())
             Controller.set_control(command)
         if t == 23:    # resolve it
-            command = ControlSetting(name=ControlSettingName.PEEP, value=10, min_value=0, max_value=20, timestamp=time.time())
+            command = ControlSetting(name=ValueName.PEEP, value=10, min_value=0, max_value=20, timestamp=time.time())
             Controller.set_control(command)
         if (t > 12+(60/17)) and (t<23):
             activealarms = Controller.get_active_alarms()
@@ -179,10 +179,10 @@ def test_alarm():
             assert 'PEEP' in activealarms.keys()
 
         if t == 15:    # trigger a BPM alarm
-            command = ControlSetting(name=ControlSettingName.BREATHS_PER_MINUTE, value=17, min_value=0, max_value=5, timestamp=time.time())
+            command = ControlSetting(name=ValueName.BREATHS_PER_MINUTE, value=17, min_value=0, max_value=5, timestamp=time.time())
             Controller.set_control(command)
         if t == 20:    # resolve it
-            command = ControlSetting(name=ControlSettingName.BREATHS_PER_MINUTE, value=17, min_value=0, max_value=20, timestamp=time.time())
+            command = ControlSetting(name=ValueName.BREATHS_PER_MINUTE, value=17, min_value=0, max_value=20, timestamp=time.time())
             Controller.set_control(command)
         if (t > 15+(60/17)) and (t<20):
             activealarms = Controller.get_active_alarms()
@@ -190,10 +190,10 @@ def test_alarm():
             assert 'BREATHS_PER_MINUTE' in activealarms.keys()
 
         if t == 17:    # Trigger a INSPIRATION_TIME_SEC alarm
-            command = ControlSetting(name=ControlSettingName.INSPIRATION_TIME_SEC, value=1.5, min_value=0, max_value=1, timestamp=time.time())
+            command = ControlSetting(name=ValueName.INSPIRATION_TIME_SEC, value=1.5, min_value=0, max_value=1, timestamp=time.time())
             Controller.set_control(command)
         if t == 22:    # resolve it
-            command = ControlSetting(name=ControlSettingName.INSPIRATION_TIME_SEC, value=1.5, min_value=0, max_value=3, timestamp=time.time())
+            command = ControlSetting(name=ValueName.INSPIRATION_TIME_SEC, value=1.5, min_value=0, max_value=3, timestamp=time.time())
             Controller.set_control(command)
         if (t > 17+(60/17)) and (t<2):
             activealarms = Controller.get_active_alarms()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,5 +1,5 @@
 import time
-from vent.common.message import ControlSetting, ControlSettingName
+from vent.common.message import ControlSetting, ValueName
 from vent.coordinator.coordinator import get_coordinator
 from vent.controller.control_module import get_control_module
 import numpy as np
@@ -7,11 +7,11 @@ import pytest
 import random
 
 
-@pytest.mark.parametrize("control_setting_name", [ControlSettingName.PIP,
-                                                  ControlSettingName.PIP_TIME,
-                                                  ControlSettingName.PEEP,
-                                                  ControlSettingName.BREATHS_PER_MINUTE,
-                                                  ControlSettingName.INSPIRATION_TIME_SEC])
+@pytest.mark.parametrize("control_setting_name", [ValueName.PIP,
+                                                  ValueName.PIP_TIME,
+                                                  ValueName.PEEP,
+                                                  ValueName.BREATHS_PER_MINUTE,
+                                                  ValueName.INSPIRATION_TIME_SEC])
 
 def test_single_process_simulation(control_setting_name):
     coordinator = get_coordinator(single_process=True, sim_mode=True)

--- a/vent/common/message.py
+++ b/vent/common/message.py
@@ -1,5 +1,27 @@
 from enum import Enum, auto
-from vent import values
+
+
+# TODO: Zhenyu's job is to make sure the print value is an intepretable string
+class ValueName(Enum):
+    #Setting that are likely important for future adjustements
+    PIP = auto()       # PIP pressure
+    PIP_TIME = auto()  # time to reach PIP
+    PEEP = auto()      # PEEP pressure
+    BREATHS_PER_MINUTE = auto()
+    INSPIRATION_TIME_SEC = auto()
+    #Settings that are read out, but can not be controlled by software
+    FIO2 = auto()
+    TEMP = auto()
+    HUMIDITY = auto()
+    VTE = auto()
+    PRESSURE = auto()
+
+class SensorValueNew:
+    def __init__(self, name, value, timestamp, loop_counter):
+        self.name = name
+        self.value = value
+        self.timestamp = timestamp
+        self.loop_counter = loop_counter
 
 
 class SensorValues:
@@ -17,27 +39,14 @@ class SensorValues:
         self.timestamp = timestamp
         self.loop_counter = loop_counter
 
-#
-# class ControlSettingName(Enum):
-#     #Setting that are likely important for future adjustements
-#     PIP = auto()       # PIP pressure
-#     PIP_TIME = auto()  # time to reach PIP
-#     PEEP = auto()      # PEEP pressure
-#     BREATHS_PER_MINUTE = auto()
-#     INSPIRATION_TIME_SEC = auto()
-#     #Settings that are read out, but can not be controlled by software
-#     FIO2 = auto()
-#     TEMP = auto()
-#     HUMIDITY = auto()
-#     VTE = auto()
 
-ControlSettingName = Enum('ControlSettingName', list(values.CONTROL.keys()))
+
 
 class ControlSetting:
     def __init__(self, name, value, min_value, max_value, timestamp):
         """
         TODO: if enum is hard to use, we may just use a predefined set, e.g. {'PIP', 'PEEP', ...}
-        :param name: enum belong to ControlSettingName
+        :param name: enum belong to ValueName
         :param value:
         :param min_value:
         :param max_value:

--- a/vent/controller/control_module.py
+++ b/vent/controller/control_module.py
@@ -4,7 +4,7 @@ import threading
 import numpy as np
 import copy 
 
-from vent.common.message import SensorValues, ControlSetting, Alarm, AlarmSeverity, ControlSettingName
+from vent.common.message import SensorValues, ControlSetting, Alarm, AlarmSeverity, ValueName
 
 
 class ControlModuleBase:
@@ -289,31 +289,31 @@ class ControlModuleBase:
         ''' Updates the entry of COPY contained in the control settings'''
         self._lock.acquire()
 
-        if control_setting.name == ControlSettingName.PIP:
+        if control_setting.name == ValueName.PIP:
             self.COPY_SET_PIP = control_setting.value
             self.COPY_PIP_min = control_setting.min_value
             self.COPY_PIP_max = control_setting.max_value
             self.COPY_PIP_lastset = control_setting.timestamp
 
-        elif control_setting.name == ControlSettingName.PIP_TIME:
+        elif control_setting.name == ValueName.PIP_TIME:
             self.COPY_SET_PIP_TIME = control_setting.value
             self.COPY_PIP_time_min = control_setting.min_value
             self.COPY_PIP_time_max = control_setting.max_value
             self.COPY_PIP_time_lastset = control_setting.timestamp
 
-        elif control_setting.name == ControlSettingName.PEEP:
+        elif control_setting.name == ValueName.PEEP:
             self.COPY_SET_PEEP = control_setting.value
             self.COPY_PEEP_min = control_setting.min_value
             self.COPY_PEEP_max = control_setting.max_value
             self.COPY_PEEP_lastset = control_setting.timestamp
 
-        elif control_setting.name == ControlSettingName.BREATHS_PER_MINUTE:
+        elif control_setting.name == ValueName.BREATHS_PER_MINUTE:
             self.COPY_SET_BPM = control_setting.value
             self.COPY_bpm_min = control_setting.min_value
             self.COPY_bpm_max = control_setting.max_value
             self.COPY_bpm_lastset = control_setting.timestamp
 
-        elif control_setting.name == ControlSettingName.INSPIRATION_TIME_SEC:
+        elif control_setting.name == ValueName.INSPIRATION_TIME_SEC:
             self.COPY_SET_I_PHASE = control_setting.value
             self.COPY_I_phase_min = control_setting.min_value
             self.COPY_I_phase_max = control_setting.max_value
@@ -324,35 +324,35 @@ class ControlModuleBase:
 
         self._lock.release()
 
-    def get_control(self, control_setting_name: ControlSettingName) -> ControlSetting:
+    def get_control(self, control_setting_name: ValueName) -> ControlSetting:
         ''' Gets values of the COPY of the control settings. '''
         
         self._lock.acquire()
-        if control_setting_name == ControlSettingName.PIP:
+        if control_setting_name == ValueName.PIP:
             return_value = ControlSetting(control_setting_name,
                                   self.COPY_SET_PIP,
                                   self.COPY_PIP_min,
                                   self.COPY_PIP_max,
                                   self.COPY_PIP_lastset)
-        elif control_setting_name == ControlSettingName.PIP_TIME:
+        elif control_setting_name == ValueName.PIP_TIME:
             return_value = ControlSetting(control_setting_name,
                                   self.COPY_SET_PIP_TIME,
                                   self.COPY_PIP_time_min,
                                   self.COPY_PIP_time_max,
                                   self.COPY_PIP_time_lastset, )
-        elif control_setting_name == ControlSettingName.PEEP:
+        elif control_setting_name == ValueName.PEEP:
             return_value = ControlSetting(control_setting_name,
                                   self.COPY_SET_PEEP,
                                   self.COPY_PEEP_min,
                                   self.COPY_PEEP_max,
                                   self.COPY_PEEP_lastset)
-        elif control_setting_name == ControlSettingName.BREATHS_PER_MINUTE:
+        elif control_setting_name == ValueName.BREATHS_PER_MINUTE:
             return_value = ControlSetting(control_setting_name,
                                   self.COPY_SET_BPM,
                                   self.COPY_bpm_min,
                                   self.COPY_bpm_max,
                                   self.COPY_bpm_lastset)
-        elif control_setting_name == ControlSettingName.INSPIRATION_TIME_SEC:
+        elif control_setting_name == ValueName.INSPIRATION_TIME_SEC:
             return_value = ControlSetting(control_setting_name,
                                   self.COPY_SET_I_PHASE,
                                   self.COPY_I_phase_min,

--- a/vent/gui/main.py
+++ b/vent/gui/main.py
@@ -3,10 +3,8 @@ import sys
 
 from PySide2 import QtWidgets, QtCore
 
-from vent import values
-from vent.common.message import ControlSetting, ControlSettingName
-from vent.gui import widgets, set_gui_instance, get_gui_instance, styles
-from vent.controller.control_module import get_control_module
+from vent.common.message import ControlSetting, ValueName
+from vent.gui import widgets, set_gui_instance, get_gui_instance, styles, values
 
 
 class Vent_Gui(QtWidgets.QMainWindow):
@@ -179,11 +177,11 @@ class Vent_Gui(QtWidgets.QMainWindow):
             value_name = self.sender().objectName()
 
 
-        control_object = ControlSetting(name=getattr(ControlSettingName, value_name),
-                                         value=new_value,
-                                         min_value = self.CONTROL[value_name]['safe_range'][0],
-                                         max_value = self.CONTROL[value_name]['safe_range'][1],
-                                         timestamp = time.time())
+        control_object = ControlSetting(name=getattr(ValueName, value_name),
+                                        value=new_value,
+                                        min_value = self.CONTROL[value_name]['safe_range'][0],
+                                        max_value = self.CONTROL[value_name]['safe_range'][1],
+                                        timestamp = time.time())
         self.coordinator.set_control(control_object)
 
 

--- a/vent/gui/values.py
+++ b/vent/gui/values.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict as odict
-
+from vent.common.message import ValueName
 from vent.gui import styles
 
 class Value(object):
@@ -108,27 +108,27 @@ class Value(object):
 
 
 MONITOR = odict({
-    'fio2': Value(**{ 'name': 'FiO2',
+    ValueName.FIO2: Value(**{ 'name': 'FiO2',
         'units': '%',
         'abs_range': (0, 100),
         'safe_range': (60, 100),
         'decimals' : 1
     }),
-    'temperature': Value(**{
+    ValueName.TEMP: Value(**{
         'name': 'Temp',
         'units': '\N{DEGREE SIGN}C',
         'abs_range': (0, 50),
         'safe_range': (20, 30),
         'decimals': 1
     }),
-    'humidity': Value(**{
+    ValueName.HUMIDITY: Value(**{
         'name': 'Humidity',
         'units': '%',
         'abs_range': (0, 100),
         'safe_range': (20, 75),
         'decimals': 1
     }),
-    'vte': Value(**{
+    ValueName.VTE: Value(**{
         'name': 'VTE',
         'units': '%',
         'abs_range': (0, 100),
@@ -152,7 +152,7 @@ Used to set alarms for out-of-bounds sensor values. These should be sent from th
 
 
 CONTROL = odict({
-    'PIP': Value(**{
+    ValueName.PIP: Value(**{
         'name': 'PIP', # (Peak Inspiratory Pressure)
         'units': 'cmH2O',
         'abs_range': (10, 30), # FIXME
@@ -160,7 +160,7 @@ CONTROL = odict({
         'default': 22,           # FIXME
         'decimals': 1          # FIXME
     }),
-    'PIP_TIME': Value(**{
+    ValueName.PIP_TIME: Value(**{
         'name': 'PIPt', #  (Peak Inspiratory Pressure)
         'units': 'seconds',
         'abs_range': (0, 1),  # FIXME
@@ -168,7 +168,7 @@ CONTROL = odict({
         'default': 0.3,  # FIXME
         'decimals': 1  # FIXME
     }),
-    'PEEP': Value(**{
+    ValueName.PEEP: Value(**{
         'name': 'PEEP', #  (Positive End Expiratory Pressure)
         'units': 'cmH2O',
         'abs_range': (0, 10),  # FIXME
@@ -176,7 +176,7 @@ CONTROL = odict({
         'default': 5,            # FIXME
         'decimals': 1           # FIXME
     }),
-    'BREATHS_PER_MINUTE': Value(**{
+    ValueName.BREATHS_PER_MINUTE: Value(**{
         'name': 'Breath Rate',
         'units': 'breaths/min',
         'abs_range': (0, 50), # FIXME
@@ -184,7 +184,7 @@ CONTROL = odict({
         'default': 17,            # FIXME
         'decimals': 1           # FIXME
     }),
-    'INSPIRATION_TIME_SEC': Value(**{
+    ValueName.INSPIRATION_TIME_SEC: Value(**{
         'name': 'Inspiration Time',
         'units': 'seconds',
         'abs_range': (0, 5),  # FIXME


### PR DESCRIPTION
As we talked about today, I define an Enum called ValueName in message.py for us to unify all sensor/control names in all modules.

@sneakers-the-rat 

- All the interface to GUI is using ValueName Enum now (The interface between the coordinator and controller still needs refactoring). 
- I modified some of your variable names in value.py. You can take a look, and do corrections. I'm not sure what I did is the most convenient way for you to use. I also move value.py into GUI folder because I think a lot of related definitions are specified for GUI (but I'm not sure this is the best approach). 