### PR TITLE
fix: stop process if normally terminate the ProcessManager

### DIFF
--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -113,8 +113,6 @@ def test_remote_coordinator(control_setting_name):
     assert c_read.max_value == c.max_value
     assert c_read.timestamp == c.timestamp
 
-    coordinator.process_manager.stop_process()
-
 
 def test_process_manager():
     # wait before
@@ -128,7 +126,7 @@ def test_process_manager():
         pass
 
     assert coordinator.is_running() == True
-    coordinator.process_manager.stop_process()
+    coordinator.process_manager.try_stop_process()
     assert coordinator.process_manager.child_pid is None
 
     try:
@@ -150,8 +148,6 @@ def test_process_manager():
     time.sleep(1)
     assert coordinator.process_manager.child_pid is not None
     assert coordinator.is_running() == False
-
-    coordinator.process_manager.stop_process()
 
 
 def test_local_sensors():
@@ -183,8 +179,6 @@ def test_remote_sensors():
     for k, v in sensor_values.items():
         assert isinstance(k, ValueName)
         assert isinstance(v, SensorValueNew)
-
-    coordinator.process_manager.stop_process()
 
 
 def test_local_alarms():
@@ -224,5 +218,3 @@ def test_remote_alarms():
     assert isinstance(alarms, list)
     for a in alarms:
         assert isinstance(a, Alarm)
-
-    coordinator.process_manager.stop_process()

--- a/vent/coordinator/process_manager.py
+++ b/vent/coordinator/process_manager.py
@@ -17,6 +17,9 @@ class ProcessManager:
         self.child_process.start()
         self.child_pid = self.child_process.pid
 
+    def __del__(self):
+        self.try_stop_process()
+
     def start_process(self):
         if self.child_process is not None:
             # Child process already started
@@ -26,7 +29,7 @@ class ProcessManager:
         self.child_process.start()
         self.child_pid = self.child_process.pid
 
-    def stop_process(self):
+    def try_stop_process(self):
         if self.child_process is not None:
             # print(f'kill process {self.child_pid}')
             self.child_process.kill()
@@ -36,8 +39,7 @@ class ProcessManager:
             self.child_pid = None
 
     def restart_process(self):
-        if self.child_process is not None:
-            self.stop_process()
+        self.try_stop_process()
         self.start_process()
 
     def heartbeat(self, timestamp):


### PR DESCRIPTION
I made a fix to ProcessManager. Previously stop_process needs to be manually called to kill the remote process. However, this complicates the testing and GUI tasks.

Therefore, the remote process is automatically killed at ProcessManager deconstruction. And I assume during GUI hang/crash, this code won't be called.